### PR TITLE
Add possibility to remove the 'var' keyword in order to use a global variable for locales

### DIFF
--- a/lib/po_to_json.rb
+++ b/lib/po_to_json.rb
@@ -50,7 +50,8 @@ class PoToJson
     generated = build_json_for(build_jed_for(@parsed))
 
     [
-      "var #{@options[:variable]} = #{@options[:variable]} || {};",
+      @options[:variable_locale_scope] ? 'var' : '',
+      "#{@options[:variable]} = #{@options[:variable]} || {};",
       "#{@options[:variable]}['#{@options[:language]}'] = #{generated};"
     ].join(" ")
   end
@@ -191,7 +192,8 @@ class PoToJson
     defaults = {
       pretty: false,
       domain: "app",
-      variable: "locales"
+      variable: "locales",
+      variable_locale_scope: true
     }
 
     defaults.merge(options)

--- a/spec/po_to_json_spec.rb
+++ b/spec/po_to_json_spec.rb
@@ -188,6 +188,17 @@ describe PoToJson do
         ).to be > 0
       end
     end
+    context "without locale scope variable" do
+      subject do
+        po_to_json.generate_for_jed("de", variable_locale_scope: false)
+      end
+
+      it "should output the var definition" do
+        expect(
+          subject.include?("locales = locales || {}; locales['de'] = ")
+        ).to be_truthy
+      end
+    end
   end
 
   # describe "generate simple hashes" do


### PR DESCRIPTION
Currently locale files output store there content in a local variable
```javascript
var locales = locales || {}; locales['de'] = 
```

it works great with sprockets but if you are using a javascript module system it doesn't work anymore.

This PR makes it possible to do things like 
```javascript
I18n.locales = I18n.locales || {}; I18n.locales['de'] = 
```