### PR TITLE
fix escape double quote in msgid issue

### DIFF
--- a/lib/po_to_json.rb
+++ b/lib/po_to_json.rb
@@ -168,7 +168,7 @@ class PoToJson
 
   def push_buffer(value, key = nil)
     value = $1 if value =~ /^"(.*)"/
-    value.gsub(/\\"/, "\"")
+    value.gsub!(/\\"/, "\"")
 
     if key.nil?
       buffer[lastkey] = [

--- a/spec/fixtures/test.po
+++ b/spec/fixtures/test.po
@@ -67,3 +67,6 @@ msgstr "Du solltest '\\' als '\\\\' escapen."
 
 msgid "Umläüte"
 msgstr "Umlaute"
+
+msgid "contains double quote, say \"Hello\""
+msgstr "contains double quote, say \"Hello\""

--- a/spec/po_to_json_spec.rb
+++ b/spec/po_to_json_spec.rb
@@ -111,6 +111,11 @@ describe PoToJson do
         eq(["Auto"])
       )
     end
+    it "should not espace double quote in msgid" do
+      expect(
+        subject["contains double quote, say \"Hello\""]
+      ).to be_truthy
+    end
   end
 
   describe "generate jed compatible" do


### PR DESCRIPTION
## Behavior
If msgid contains double quote, method push_buffer will escape it then parsing. which mismatch the original msgid

let's say we have following msgid `contains double quote, say "Hello"`
```po
msgid "contains double quote, say \"Hello\""
msgstr "contains double quote, say \"Hello\""
```

after parsing, content will be
```ruby
{"contains double quote, say \\\"Hello\\\""=>["contains double quote, say \\\"Hello\\\""]}
```

the msgid are wrong `contains double quote, say \"Hello\"`

## Analyze
in method push_buffer, `value.gsub!(/\\"/, "\"")` will trying to fix it, however method gsub will NOT modify the original string object, we should use gsub! instead.